### PR TITLE
ASISpaceTimeMap - explicitly naming ivar timePointer in interface definition

### DIFF
--- a/Classes/ASISpaceTimeMap.h
+++ b/Classes/ASISpaceTimeMap.h
@@ -19,6 +19,7 @@
 	// When incrementTime is called, we increment this, or reset it to zero if we're at the end of the time span
 	// This allows us to perform path finding part way through the time span
 	unsigned char currentTimeStep;
+	unsigned char timePointer;
 	
 }
 


### PR DESCRIPTION
Need to add timePointer as  explicit variable in the interface definition so that the code builds on Cocoa/OSX 
